### PR TITLE
add multiple control compatibility #2

### DIFF
--- a/CCPropGen.Maui.Demo/CCPropGen.Maui.Demo.csproj
+++ b/CCPropGen.Maui.Demo/CCPropGen.Maui.Demo.csproj
@@ -61,6 +61,9 @@
 	  <MauiXaml Update="CCPropGenEntry.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="MultipleControlsView.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="MultipleValuesEntry.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/CCPropGen.Maui.Demo/MainPage.xaml
+++ b/CCPropGen.Maui.Demo/MainPage.xaml
@@ -51,6 +51,11 @@
                 Text="{Binding MaxLength}"
                 />
 
+            <local:MultipleControlsView
+                Text="{Binding EntryText}"
+                FontSize="{Binding MaxLength}"
+                />
+
         </VerticalStackLayout>
     </ScrollView>
  

--- a/CCPropGen.Maui.Demo/MultipleControlsView.xaml
+++ b/CCPropGen.Maui.Demo/MultipleControlsView.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="CCPropGen.Maui.Demo.MultipleControlsView">
+    <StackLayout>
+        <Label x:Name="ControlLabel"
+               Text="ProvaProva"/>
+        <Entry x:Name="ControlEntry" />
+    </StackLayout>
+</ContentView>

--- a/CCPropGen.Maui.Demo/MultipleControlsView.xaml.cs
+++ b/CCPropGen.Maui.Demo/MultipleControlsView.xaml.cs
@@ -1,0 +1,14 @@
+using Maui.CCPropGen;
+
+namespace CCPropGen.Maui.Demo;
+
+[CCPropGen("ControlEntry", typeof(Entry), "Text", typeof(string))]
+[CCPropGen("ControlLabel", typeof(Label), "FontSize", typeof(double))]
+public partial class MultipleControlsView : ContentView
+{
+	public MultipleControlsView()
+	{
+		InitializeComponent();
+		InitializeCCPropGen();
+	}
+}

--- a/CCPropGen/Core/Generator/PropGenerator.cs
+++ b/CCPropGen/Core/Generator/PropGenerator.cs
@@ -41,7 +41,7 @@ namespace CCPropGen.Core.Generator
                     return;
                 }
 
-                var attributeValues = SourceGeneratorUtils.GetAttributeValues(
+                var attributeValues = SourceGeneratorUtils.GetAttributeValuesList(
                     context.Compilation,
                     syntaxReceiver.ControlClassSyntaxesWithAttributes[userClass]);
 
@@ -49,7 +49,7 @@ namespace CCPropGen.Core.Generator
                 {
                     Namespace = @namespace.ToString(),
                     ClassName = userClass.Identifier.Text.ToString(),
-                    AttributeValues = attributeValues
+                    AttributeValuesList = attributeValues
                 }.BuildSource();
 
                 context.AddSource($"{userClass.Identifier.Text}", generatedClass);

--- a/CCPropGen/Core/SyntaxReceiver/CCPropSyntaxReceiver.cs
+++ b/CCPropGen/Core/SyntaxReceiver/CCPropSyntaxReceiver.cs
@@ -8,7 +8,7 @@ namespace CCPropGen.Core.SyntaxReceiver
 {
     internal class CCPropSyntaxReceiver : ISyntaxReceiver
     {
-        public Dictionary<ClassDeclarationSyntax, AttributeSyntax> ControlClassSyntaxesWithAttributes { get; }
+        public Dictionary<ClassDeclarationSyntax, List<AttributeSyntax>> ControlClassSyntaxesWithAttributes { get; }
 
         public CCPropSyntaxReceiver()
         {
@@ -32,9 +32,18 @@ namespace CCPropGen.Core.SyntaxReceiver
 
                 foreach (var attribute in attributes.Attributes)
                 {
-                    if (attribute.Name.GetText().ToString() == AttributeConstants.ATTRIBUTE_NAME)
+                    if (attribute.Name.GetText().ToString() != AttributeConstants.ATTRIBUTE_NAME)
                     {
-                        ControlClassSyntaxesWithAttributes[classDeclarationSyntax] = attribute;
+                        continue;
+                    }
+
+                    if (ControlClassSyntaxesWithAttributes.ContainsKey(classDeclarationSyntax))
+                    {
+                        ControlClassSyntaxesWithAttributes[classDeclarationSyntax].Add(attribute);
+                    }
+                    else
+                    {
+                        ControlClassSyntaxesWithAttributes[classDeclarationSyntax] = new() { attribute };
                     }
                 }
             }


### PR DESCRIPTION
If a custom view has two or more controls inside, properties of each control can be bound applying several times `CCPropGen` attribute.

Currently, properties must have different names (#4).

